### PR TITLE
Replace municipalityId with municipalityName and guard against deleting admin

### DIFF
--- a/src/integration-test/resources/CreateUsersIT/__files/test01_createUser/request.json
+++ b/src/integration-test/resources/CreateUsersIT/__files/test01_createUser/request.json
@@ -1,7 +1,7 @@
 {
 	"email": "test@sundsvall.se",
 	"phoneNumber": "0701234567",
-	"municipalityId": "2281",
+	"municipalityName": "2281",
 	"password": "password",
 	"status": "INACTIVE",
 	"role": "USER"

--- a/src/integration-test/resources/GetUserIT/__files/test01_getUserByEmail/response.json
+++ b/src/integration-test/resources/GetUserIT/__files/test01_getUserByEmail/response.json
@@ -2,7 +2,7 @@
 	"id": 1,
 	"email": "testmail1@sundsvall.se",
 	"phoneNumber": "0701740669",
-	"municipalityId": "2281",
+	"municipalityName": "Sundsvall",
 	"status": "ACTIVE",
 	"role": "USER"
 }

--- a/src/integration-test/resources/GetUserIT/__files/test02_getUserbyId/response.json
+++ b/src/integration-test/resources/GetUserIT/__files/test02_getUserbyId/response.json
@@ -2,7 +2,7 @@
 	"id": 1,
 	"email": "testmail1@sundsvall.se",
 	"phoneNumber": "0701740669",
-	"municipalityId": "2281",
+	"municipalityName": "Sundsvall",
 	"status": "ACTIVE",
 	"role": "USER"
 }

--- a/src/integration-test/resources/UpdateUserIT/__files/test01_updateUserWithId/request.json
+++ b/src/integration-test/resources/UpdateUserIT/__files/test01_updateUserWithId/request.json
@@ -1,7 +1,7 @@
 {
 	"email": "testmail1@sundsvall.se",
 	"phoneNumber": "0701234567",
-	"municipalityId": "2281",
+	"municipalityName": "2281",
 	"status": "INACTIVE",
 	"role": "USER"
 }

--- a/src/integration-test/resources/UpdateUserIT/__files/test01_updateUserWithId/response.json
+++ b/src/integration-test/resources/UpdateUserIT/__files/test01_updateUserWithId/response.json
@@ -2,7 +2,7 @@
 	"id": 1,
 	"email": "testmail1@sundsvall.se",
 	"phoneNumber": "0701234567",
-	"municipalityId": "2281",
+	"municipalityName": "Sundsvall",
 	"status": "INACTIVE",
 	"role": "USER"
 }

--- a/src/integration-test/resources/UpdateUserIT/__files/test02_updateUserWithIdNotFound/request.json
+++ b/src/integration-test/resources/UpdateUserIT/__files/test02_updateUserWithIdNotFound/request.json
@@ -1,7 +1,7 @@
 {
 	"email": "testmail@sundsvall.se",
 	"phoneNumber": "0706435467",
-	"municipalityId": "2281",
+	"municipalityName": "2281",
 	"status": "ACTIVE",
 	"role": "USER"
 }

--- a/src/main/java/se/sundsvall/users/api/model/BaseUserRequest.java
+++ b/src/main/java/se/sundsvall/users/api/model/BaseUserRequest.java
@@ -1,0 +1,83 @@
+package se.sundsvall.users.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.Objects;
+import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
+import se.sundsvall.users.api.validation.ValidEnum;
+import se.sundsvall.users.api.validation.ValidMunicipalityName;
+import se.sundsvall.users.integration.db.model.enums.Role;
+import se.sundsvall.users.integration.db.model.enums.Status;
+
+public abstract class BaseUserRequest {
+
+	@Schema(description = "Telefonnummer", example = "0701740669")
+	@NotBlank(message = "cannot be blank")
+	@ValidMobileNumber(message = "must be a valid mobile number")
+	private String phoneNumber;
+
+	@Schema(description = "Kommunnamn", example = "Sundsvall")
+	@NotBlank(message = "cannot be blank")
+	@ValidMunicipalityName(message = "must be a valid municipality name")
+	private String municipalityName;
+
+	@Schema(description = "Status", example = "ACTIVE")
+	@ValidEnum(message = "must be ACTIVE, INACTIVE or SUSPENDED", enumClass = Status.class, ignoreCase = true)
+	private String status;
+
+	@Schema(description = "Roll", example = "USER")
+	@ValidEnum(message = "must be USER or ADMIN", enumClass = Role.class, ignoreCase = true)
+	private String role;
+
+	public String getPhoneNumber() {
+		return phoneNumber;
+	}
+
+	public void setPhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
+
+	public String getMunicipalityName() {
+		return municipalityName;
+	}
+
+	public void setMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getRole() {
+		return role;
+	}
+
+	public void setRole(String role) {
+		this.role = role;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(phoneNumber, municipalityName, status, role);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		BaseUserRequest that = (BaseUserRequest) o;
+		return Objects.equals(phoneNumber, that.phoneNumber)
+			&& Objects.equals(municipalityName, that.municipalityName)
+			&& Objects.equals(status, that.status)
+			&& Objects.equals(role, that.role);
+	}
+}

--- a/src/main/java/se/sundsvall/users/api/model/UpdateUserRequest.java
+++ b/src/main/java/se/sundsvall/users/api/model/UpdateUserRequest.java
@@ -4,36 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
-import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
-import se.sundsvall.users.api.validation.ValidEnum;
-import se.sundsvall.users.api.validation.ValidMunicipalityName;
-import se.sundsvall.users.integration.db.model.enums.Role;
-import se.sundsvall.users.integration.db.model.enums.Status;
 
-public class UpdateUserRequest {
+public class UpdateUserRequest extends BaseUserRequest {
 
 	@Schema(description = "E-postadress", example = "")
 	@NotBlank(message = "cannot be blank")
 	@Email
 	private String email;
-
-	@Schema(description = "Telefonnummer", example = "0701740669")
-	@NotBlank(message = "cannot be blank")
-	@ValidMobileNumber(message = "must be a valid mobile number")
-	private String phoneNumber;
-
-	@Schema(description = "Kommunnamn", example = "Sundsvall")
-	@NotBlank(message = "cannot be blank")
-	@ValidMunicipalityName(message = "must be a valid municipality name")
-	private String municipalityName;
-
-	@Schema(description = "Status", example = "ACTIVE")
-	@ValidEnum(message = "must be ACTIVE, INACTIVE or SUSPENDED", enumClass = Status.class, ignoreCase = true)
-	private String status;
-
-	@Schema(description = "Roll", example = "USER")
-	@ValidEnum(message = "must be USER or ADMIN", enumClass = Role.class, ignoreCase = true)
-	private String role;
 
 	public static UpdateUserRequest create() {
 		return new UpdateUserRequest();
@@ -52,61 +29,29 @@ public class UpdateUserRequest {
 		return this;
 	}
 
-	public String getPhoneNumber() {
-		return phoneNumber;
-	}
-
-	public void setPhoneNumber(String phoneNumber) {
-		this.phoneNumber = phoneNumber;
-	}
-
 	public UpdateUserRequest withPhoneNumber(String phoneNumber) {
-		this.phoneNumber = phoneNumber;
+		setPhoneNumber(phoneNumber);
 		return this;
-	}
-
-	public String getMunicipalityName() {
-		return municipalityName;
-	}
-
-	public void setMunicipalityName(String municipalityName) {
-		this.municipalityName = municipalityName;
 	}
 
 	public UpdateUserRequest withMunicipalityName(String municipalityName) {
-		this.municipalityName = municipalityName;
+		setMunicipalityName(municipalityName);
 		return this;
-	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public void setStatus(String status) {
-		this.status = status;
 	}
 
 	public UpdateUserRequest withStatus(String status) {
-		this.status = status;
+		setStatus(status);
 		return this;
 	}
 
-	public String getRole() {
-		return role;
-	}
-
-	public void setRole(String role) {
-		this.role = role;
-	}
-
 	public UpdateUserRequest withRole(String role) {
-		this.role = role;
+		setRole(role);
 		return this;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(email, municipalityName, phoneNumber, status, role);
+		return Objects.hash(super.hashCode(), email);
 	}
 
 	@Override
@@ -118,10 +63,6 @@ public class UpdateUserRequest {
 			return false;
 		}
 		UpdateUserRequest that = (UpdateUserRequest) o;
-		return Objects.equals(email, that.email)
-			&& Objects.equals(phoneNumber, that.phoneNumber)
-			&& Objects.equals(status, that.status)
-			&& Objects.equals(municipalityName, that.municipalityName)
-			&& Objects.equals(role, that.role);
+		return super.equals(o) && Objects.equals(email, that.email);
 	}
 }

--- a/src/main/java/se/sundsvall/users/api/model/UpdateUserRequest.java
+++ b/src/main/java/se/sundsvall/users/api/model/UpdateUserRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
 import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
-import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 import se.sundsvall.users.api.validation.ValidEnum;
+import se.sundsvall.users.api.validation.ValidMunicipalityName;
 import se.sundsvall.users.integration.db.model.enums.Role;
 import se.sundsvall.users.integration.db.model.enums.Status;
 
@@ -22,10 +22,10 @@ public class UpdateUserRequest {
 	@ValidMobileNumber(message = "must be a valid mobile number")
 	private String phoneNumber;
 
-	@Schema(description = "Kommun", example = "2281")
+	@Schema(description = "Kommunnamn", example = "Sundsvall")
 	@NotBlank(message = "cannot be blank")
-	@ValidMunicipalityId(message = "must be a valid Municipality-ID")
-	private String municipalityId;
+	@ValidMunicipalityName(message = "must be a valid municipality name")
+	private String municipalityName;
 
 	@Schema(description = "Status", example = "ACTIVE")
 	@ValidEnum(message = "must be ACTIVE, INACTIVE or SUSPENDED", enumClass = Status.class, ignoreCase = true)
@@ -65,16 +65,16 @@ public class UpdateUserRequest {
 		return this;
 	}
 
-	public String getMunicipalityId() {
-		return municipalityId;
+	public String getMunicipalityName() {
+		return municipalityName;
 	}
 
-	public void setMunicipalityId(String municipalityId) {
-		this.municipalityId = municipalityId;
+	public void setMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
 	}
 
-	public UpdateUserRequest withMunicipalityId(String municipalityId) {
-		this.municipalityId = municipalityId;
+	public UpdateUserRequest withMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
 		return this;
 	}
 
@@ -106,7 +106,7 @@ public class UpdateUserRequest {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(email, municipalityId, phoneNumber, status, role);
+		return Objects.hash(email, municipalityName, phoneNumber, status, role);
 	}
 
 	@Override
@@ -121,7 +121,7 @@ public class UpdateUserRequest {
 		return Objects.equals(email, that.email)
 			&& Objects.equals(phoneNumber, that.phoneNumber)
 			&& Objects.equals(status, that.status)
-			&& Objects.equals(municipalityId, that.municipalityId)
+			&& Objects.equals(municipalityName, that.municipalityName)
 			&& Objects.equals(role, that.role);
 	}
 }

--- a/src/main/java/se/sundsvall/users/api/model/UserRequest.java
+++ b/src/main/java/se/sundsvall/users/api/model/UserRequest.java
@@ -4,43 +4,24 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
-import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
-import se.sundsvall.users.api.validation.ValidEnum;
-import se.sundsvall.users.api.validation.ValidMunicipalityName;
-import se.sundsvall.users.integration.db.model.enums.Role;
-import se.sundsvall.users.integration.db.model.enums.Status;
 
-public class UserRequest {
+public class UserRequest extends BaseUserRequest {
 
 	@Schema(description = "Epost-adress", example = "kalle.kula@sundsvall.se")
 	@Email(message = "must be a valid Email-adress", regexp = "^[A-Za-zÅÄÖåäö0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
 	@NotBlank(message = "cannot be blank")
 	private String email;
 
-	@Schema(description = "Telefonnummer", example = "0701740669")
-	@NotBlank(message = "cannot be blank")
-	@ValidMobileNumber(message = "must be a valid mobile number")
-	private String phoneNumber;
-
-	@Schema(description = "Kommunnamn", example = "Sundsvall")
-	@NotBlank(message = "cannot be blank")
-	@ValidMunicipalityName(message = "must be a valid municipality name")
-	private String municipalityName;
-
-	@Schema(description = "Status", example = "ACTIVE")
-	@ValidEnum(message = "must be ACTIVE, INACTIVE or SUSPENDED", enumClass = Status.class, ignoreCase = true)
-	private String status;
-
 	@Schema(description = "Lösenord", example = "mittLösenord")
 	@NotBlank
 	private String password;
 
-	@Schema(description = "Roll", example = "USER")
-	@ValidEnum(message = "must be USER or ADMIN", enumClass = Role.class, ignoreCase = true)
-	private String role = "USER";
-
 	public static UserRequest create() {
 		return new UserRequest();
+	}
+
+	public UserRequest() {
+		setRole("USER");
 	}
 
 	public String getEmail() {
@@ -53,45 +34,6 @@ public class UserRequest {
 
 	public UserRequest withEmail(String email) {
 		this.email = email;
-		return this;
-	}
-
-	public String getPhoneNumber() {
-		return phoneNumber;
-	}
-
-	public void setPhoneNumber(String phoneNumber) {
-		this.phoneNumber = phoneNumber;
-	}
-
-	public UserRequest withPhoneNumber(String phoneNumber) {
-		this.phoneNumber = phoneNumber;
-		return this;
-	}
-
-	public String getMunicipalityName() {
-		return municipalityName;
-	}
-
-	public void setMunicipalityName(String municipalityName) {
-		this.municipalityName = municipalityName;
-	}
-
-	public UserRequest withMunicipalityName(String municipalityName) {
-		this.municipalityName = municipalityName;
-		return this;
-	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public void setStatus(String status) {
-		this.status = status;
-	}
-
-	public UserRequest withStatus(String status) {
-		this.status = status;
 		return this;
 	}
 
@@ -108,22 +50,29 @@ public class UserRequest {
 		return this;
 	}
 
-	public String getRole() {
-		return role;
+	public UserRequest withPhoneNumber(String phoneNumber) {
+		setPhoneNumber(phoneNumber);
+		return this;
 	}
 
-	public void setRole(String role) {
-		this.role = role;
+	public UserRequest withMunicipalityName(String municipalityName) {
+		setMunicipalityName(municipalityName);
+		return this;
+	}
+
+	public UserRequest withStatus(String status) {
+		setStatus(status);
+		return this;
 	}
 
 	public UserRequest withRole(String role) {
-		this.role = role;
+		setRole(role);
 		return this;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(municipalityName, email, phoneNumber, status);
+		return Objects.hash(super.hashCode(), email);
 	}
 
 	@Override
@@ -135,7 +84,6 @@ public class UserRequest {
 			return false;
 		}
 		UserRequest that = (UserRequest) o;
-		return Objects.equals(email, that.email) && Objects.equals(phoneNumber, that.phoneNumber)
-			&& Objects.equals(status, that.status) && Objects.equals(municipalityName, that.municipalityName);
+		return super.equals(o) && Objects.equals(email, that.email);
 	}
 }

--- a/src/main/java/se/sundsvall/users/api/model/UserRequest.java
+++ b/src/main/java/se/sundsvall/users/api/model/UserRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Objects;
 import se.sundsvall.dept44.common.validators.annotation.ValidMobileNumber;
-import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 import se.sundsvall.users.api.validation.ValidEnum;
+import se.sundsvall.users.api.validation.ValidMunicipalityName;
 import se.sundsvall.users.integration.db.model.enums.Role;
 import se.sundsvall.users.integration.db.model.enums.Status;
 
@@ -22,10 +22,10 @@ public class UserRequest {
 	@ValidMobileNumber(message = "must be a valid mobile number")
 	private String phoneNumber;
 
-	@Schema(description = "Kommun", example = "2281")
+	@Schema(description = "Kommunnamn", example = "Sundsvall")
 	@NotBlank(message = "cannot be blank")
-	@ValidMunicipalityId(message = "must be a valid Municipality-ID")
-	private String municipalityId;
+	@ValidMunicipalityName(message = "must be a valid municipality name")
+	private String municipalityName;
 
 	@Schema(description = "Status", example = "ACTIVE")
 	@ValidEnum(message = "must be ACTIVE, INACTIVE or SUSPENDED", enumClass = Status.class, ignoreCase = true)
@@ -69,16 +69,16 @@ public class UserRequest {
 		return this;
 	}
 
-	public String getMunicipalityId() {
-		return municipalityId;
+	public String getMunicipalityName() {
+		return municipalityName;
 	}
 
-	public void setMunicipalityId(String municipalityId) {
-		this.municipalityId = municipalityId;
+	public void setMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
 	}
 
-	public UserRequest withMunicipalityId(String municipalityId) {
-		this.municipalityId = municipalityId;
+	public UserRequest withMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
 		return this;
 	}
 
@@ -123,7 +123,7 @@ public class UserRequest {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(municipalityId, email, phoneNumber, status);
+		return Objects.hash(municipalityName, email, phoneNumber, status);
 	}
 
 	@Override
@@ -136,6 +136,6 @@ public class UserRequest {
 		}
 		UserRequest that = (UserRequest) o;
 		return Objects.equals(email, that.email) && Objects.equals(phoneNumber, that.phoneNumber)
-			&& Objects.equals(status, that.status) && Objects.equals(municipalityId, that.municipalityId);
+			&& Objects.equals(status, that.status) && Objects.equals(municipalityName, that.municipalityName);
 	}
 }

--- a/src/main/java/se/sundsvall/users/api/model/UserResponse.java
+++ b/src/main/java/se/sundsvall/users/api/model/UserResponse.java
@@ -11,8 +11,8 @@ public class UserResponse {
 	private String email;
 	@Schema(description = "Telefonnummer", example = "0701740669")
 	private String phoneNumber;
-	@Schema(description = "Kommun-id", example = "2281")
-	private String municipalityId;
+	@Schema(description = "Kommunnamn", example = "Sundsvall")
+	private String municipalityName;
 	@Schema(description = "Status", example = "ACTIVE")
 	private String status;
 	@Schema(description = "Roll", example = "USER")
@@ -22,16 +22,16 @@ public class UserResponse {
 		return new UserResponse();
 	}
 
-	public String getMunicipalityId() {
-		return municipalityId;
+	public String getMunicipalityName() {
+		return municipalityName;
 	}
 
-	public void setMunicipalityId(String municipalityId) {
-		this.municipalityId = municipalityId;
+	public void setMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
 	}
 
-	public UserResponse withMunicipalityId(String municipalityId) {
-		this.municipalityId = municipalityId;
+	public UserResponse withMunicipalityName(String municipalityName) {
+		this.municipalityName = municipalityName;
 		return this;
 	}
 
@@ -102,7 +102,7 @@ public class UserResponse {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(municipalityId, email, phoneNumber, status);
+		return Objects.hash(municipalityName, email, phoneNumber, status);
 	}
 
 	@Override
@@ -115,7 +115,7 @@ public class UserResponse {
 		}
 		UserResponse that = (UserResponse) o;
 		return Objects.equals(email, that.email) && Objects.equals(phoneNumber, that.phoneNumber)
-			&& Objects.equals(status, that.status) && Objects.equals(municipalityId, that.municipalityId);
+			&& Objects.equals(status, that.status) && Objects.equals(municipalityName, that.municipalityName);
 
 	}
 }

--- a/src/main/java/se/sundsvall/users/api/validation/ValidMunicipalityName.java
+++ b/src/main/java/se/sundsvall/users/api/validation/ValidMunicipalityName.java
@@ -1,0 +1,24 @@
+package se.sundsvall.users.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+import se.sundsvall.users.api.validation.impl.MunicipalityNameValidator;
+
+@Documented
+@Constraint(validatedBy = MunicipalityNameValidator.class)
+@Target({
+	ElementType.METHOD, ElementType.FIELD,
+	ElementType.ANNOTATION_TYPE,
+	ElementType.CONSTRUCTOR,
+	ElementType.PARAMETER,
+	ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMunicipalityName {
+	String message() default "must be a valid municipality name";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/se/sundsvall/users/api/validation/impl/MunicipalityNameValidator.java
+++ b/src/main/java/se/sundsvall/users/api/validation/impl/MunicipalityNameValidator.java
@@ -1,0 +1,17 @@
+package se.sundsvall.users.api.validation.impl;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import se.sundsvall.dept44.util.MunicipalityUtils;
+import se.sundsvall.users.api.validation.ValidMunicipalityName;
+
+public class MunicipalityNameValidator implements ConstraintValidator<ValidMunicipalityName, String> {
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return false;
+		}
+		return MunicipalityUtils.existsByName(value) || MunicipalityUtils.existsById(value);
+	}
+}

--- a/src/main/java/se/sundsvall/users/integration/db/UserRepository.java
+++ b/src/main/java/se/sundsvall/users/integration/db/UserRepository.java
@@ -1,14 +1,18 @@
 package se.sundsvall.users.integration.db;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.sundsvall.users.integration.db.model.UserEntity;
+import se.sundsvall.users.integration.db.model.enums.Role;
 
 public interface UserRepository extends JpaRepository<UserEntity, String> {
 
 	Optional<UserEntity> findByEmail(String email);
 
 	Optional<UserEntity> findById(Long id);
+
+	List<UserEntity> findAllByRole(Role role);
 
 	void deleteByEmail(String email);
 

--- a/src/main/java/se/sundsvall/users/service/Mapper/UserMapper.java
+++ b/src/main/java/se/sundsvall/users/service/Mapper/UserMapper.java
@@ -2,6 +2,7 @@ package se.sundsvall.users.service.Mapper;
 
 import java.util.Optional;
 import org.springframework.stereotype.Component;
+import se.sundsvall.dept44.util.MunicipalityUtils;
 import se.sundsvall.users.api.model.UserRequest;
 import se.sundsvall.users.api.model.UserResponse;
 import se.sundsvall.users.integration.db.model.UserEntity;
@@ -17,7 +18,9 @@ public class UserMapper {
 				.withEmail(entity.getEmail())
 				.withId(entity.getId())
 				.withPhoneNumber(entity.getPhoneNumber())
-				.withMunicipalityId(entity.getMunicipalityId())
+				.withMunicipalityName(Optional.ofNullable(MunicipalityUtils.findById(entity.getMunicipalityId()))
+					.map(m -> m.name())
+					.orElse(null))
 				.withStatus(String.valueOf(entity.getStatus()))
 				.withRole(entity.getRole() != null ? entity.getRole().name() : null))
 			.orElse(null);
@@ -28,12 +31,19 @@ public class UserMapper {
 			.map(request -> UserEntity.create()
 				.withEmail(request.getEmail())
 				.withPhoneNumber(request.getPhoneNumber())
-				.withMunicipalityId(request.getMunicipalityId())
+				.withMunicipalityId(resolveMunicipalityId(request.getMunicipalityName()))
 				.withPassword(encryptedPassword)
 				.withStatus(Status.valueOf(request.getStatus().toUpperCase()))
 				.withRole(request.getRole() != null
 					? Role.valueOf(request.getRole().toUpperCase())
 					: Role.USER))
 			.orElse(null);
+	}
+
+	private String resolveMunicipalityId(final String input) {
+		if (MunicipalityUtils.existsById(input)) {
+			return input;
+		}
+		return MunicipalityUtils.findByName(input).id();
 	}
 }

--- a/src/main/java/se/sundsvall/users/service/Mapper/UserMapper.java
+++ b/src/main/java/se/sundsvall/users/service/Mapper/UserMapper.java
@@ -40,7 +40,7 @@ public class UserMapper {
 			.orElse(null);
 	}
 
-	private String resolveMunicipalityId(final String input) {
+	public String resolveMunicipalityId(final String input) {
 		if (MunicipalityUtils.existsById(input)) {
 			return input;
 		}

--- a/src/main/java/se/sundsvall/users/service/UserService.java
+++ b/src/main/java/se/sundsvall/users/service/UserService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import se.sundsvall.dept44.problem.*;
+import se.sundsvall.dept44.util.MunicipalityUtils;
 import se.sundsvall.users.api.model.UpdateUserRequest;
 import se.sundsvall.users.api.model.UserRequest;
 import se.sundsvall.users.api.model.UserResponse;
@@ -75,7 +76,7 @@ public class UserService {
 			.withId(id)
 			.withEmail(userRequest.getEmail())
 			.withPhoneNumber(userRequest.getPhoneNumber())
-			.withMunicipalityId(userRequest.getMunicipalityId())
+			.withMunicipalityId(resolveMunicipalityId(userRequest.getMunicipalityName()))
 			.withStatus(Status.valueOf(userRequest.getStatus().toUpperCase()));
 
 		if (userRequest.getRole() != null) {
@@ -87,17 +88,34 @@ public class UserService {
 		return userMapper.toUserResponse(userEntity);
 	}
 
+	private String resolveMunicipalityId(final String input) {
+		if (MunicipalityUtils.existsById(input)) {
+			return input;
+		}
+		return MunicipalityUtils.findByName(input).id();
+	}
+
 	// DELETE
 	public void deleteUserByEmail(String email) {
+		var userEntity = userRepository.findByEmail(email)
+			.orElseThrow(() -> Problem.valueOf(NOT_FOUND, format(USER_NOT_FOUND, email)));
+		if (userEntity.getRole() == Role.ADMIN) {
+			throw Problem.valueOf(org.springframework.http.HttpStatus.FORBIDDEN, "admin users cannot be deleted");
+		}
 		userRepository.deleteByEmail(email);
 	}
 
 	public void deleteUserById(Long id) {
+		var userEntity = userRepository.findById(id)
+			.orElseThrow(() -> Problem.valueOf(NOT_FOUND, format(USER_NOT_FOUND, id)));
+		if (userEntity.getRole() == Role.ADMIN) {
+			throw Problem.valueOf(org.springframework.http.HttpStatus.FORBIDDEN, "admin users cannot be deleted");
+		}
 		userRepository.deleteById(id);
 	}
 
 	public List<UserResponse> getAllUsers() {
-		return userRepository.findAll().stream()
+		return userRepository.findAllByRole(Role.USER).stream()
 			.map(userMapper::toUserResponse)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/se/sundsvall/users/service/UserService.java
+++ b/src/main/java/se/sundsvall/users/service/UserService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import se.sundsvall.dept44.problem.*;
-import se.sundsvall.dept44.util.MunicipalityUtils;
 import se.sundsvall.users.api.model.UpdateUserRequest;
 import se.sundsvall.users.api.model.UserRequest;
 import se.sundsvall.users.api.model.UserResponse;
@@ -76,7 +75,7 @@ public class UserService {
 			.withId(id)
 			.withEmail(userRequest.getEmail())
 			.withPhoneNumber(userRequest.getPhoneNumber())
-			.withMunicipalityId(resolveMunicipalityId(userRequest.getMunicipalityName()))
+			.withMunicipalityId(userMapper.resolveMunicipalityId(userRequest.getMunicipalityName()))
 			.withStatus(Status.valueOf(userRequest.getStatus().toUpperCase()));
 
 		if (userRequest.getRole() != null) {
@@ -86,13 +85,6 @@ public class UserService {
 		userRepository.save(updated);
 
 		return userMapper.toUserResponse(userEntity);
-	}
-
-	private String resolveMunicipalityId(final String input) {
-		if (MunicipalityUtils.existsById(input)) {
-			return input;
-		}
-		return MunicipalityUtils.findByName(input).id();
 	}
 
 	// DELETE

--- a/src/test/java/se/sundsvall/users/api/UserResourceFailuresTest.java
+++ b/src/test/java/se/sundsvall/users/api/UserResourceFailuresTest.java
@@ -52,7 +52,7 @@ class UserResourceFailuresTest {
 		final var userRequest = UserRequest.create()
 			.withEmail("notamailtestcom")
 			.withPhoneNumber("number0000000000")
-			.withMunicipalityId("id2222")
+			.withMunicipalityName("id2222")
 			.withStatus("status");
 		// Act
 		final var response = webTestClient.post()
@@ -77,7 +77,7 @@ class UserResourceFailuresTest {
 				tuple("status", "must be ACTIVE, INACTIVE or SUSPENDED"),
 				tuple("phoneNumber", "must be a valid mobile number"),
 				tuple("password", "must not be blank"),
-				tuple("municipalityId", "must be a valid Municipality-ID"));
+				tuple("municipalityName", "must be a valid municipality name"));
 
 	}
 
@@ -112,7 +112,7 @@ class UserResourceFailuresTest {
 		final var userRequest = UpdateUserRequest.create()
 			.withEmail("test@testmail.com")
 			.withPhoneNumber("numberplate")
-			.withMunicipalityId("municipalityId")
+			.withMunicipalityName("municipalityId")
 			.withStatus("status");
 
 		// act
@@ -134,7 +134,7 @@ class UserResourceFailuresTest {
 			.containsExactlyInAnyOrder(
 				tuple("status", "must be ACTIVE, INACTIVE or SUSPENDED"),
 				tuple("phoneNumber", "must be a valid mobile number"),
-				tuple("municipalityId", "must be a valid Municipality-ID"),
+				tuple("municipalityName", "must be a valid municipality name"),
 				tuple("role", "must be USER or ADMIN"));
 	}
 }

--- a/src/test/java/se/sundsvall/users/api/UserResourceTest.java
+++ b/src/test/java/se/sundsvall/users/api/UserResourceTest.java
@@ -52,13 +52,13 @@ class UserResourceTest {
 
 		final var userRequest = UserRequest.create()
 			.withEmail("test@testmail.com")
-			.withMunicipalityId("2281")
+			.withMunicipalityName("Sundsvall")
 			.withPhoneNumber("0701740649")
 			.withPassword("password")
 			.withStatus("ACTIVE");
 		final var userResponse = UserResponse.create()
 			.withEmail("test@testmail.com")
-			.withMunicipalityId("2281")
+			.withMunicipalityName("Sundsvall")
 			.withPhoneNumber("0701740649")
 			.withStatus("ACTIVE")
 			.withRole("user");
@@ -85,7 +85,7 @@ class UserResourceTest {
 		final var email = "kalle.kula@sundsvall.se";
 		final var userResponse = UserResponse.create()
 			.withEmail(email)
-			.withMunicipalityId("2281")
+			.withMunicipalityName("Sundsvall")
 			.withPhoneNumber("0701740629")
 			.withStatus("ACTIVE")
 			.withRole("user");
@@ -109,7 +109,7 @@ class UserResourceTest {
 		final var id = 1L;
 		final var userResponse = UserResponse.create()
 			.withId(id)
-			.withMunicipalityId("2281")
+			.withMunicipalityName("Sundsvall")
 			.withPhoneNumber("0701740629")
 			.withStatus("ACTIVE")
 			.withRole("user");
@@ -148,13 +148,13 @@ class UserResourceTest {
 		final var id = 1L;
 		final var userRequest = UpdateUserRequest.create()
 			.withEmail("test@test.com")
-			.withMunicipalityId("2281")
+			.withMunicipalityName("Sundsvall")
 			.withPhoneNumber("0701740669")
 			.withStatus("ACTIVE")
 			.withRole("user");
 		final var userResponse = UserResponse.create()
 			.withEmail("test@test.com")
-			.withMunicipalityId("2281")
+			.withMunicipalityName("Sundsvall")
 			.withPhoneNumber("0701740619")
 			.withStatus("ACTIVE")
 			.withRole("user");

--- a/src/test/java/se/sundsvall/users/api/model/UpdateUserRequestTest.java
+++ b/src/test/java/se/sundsvall/users/api/model/UpdateUserRequestTest.java
@@ -21,16 +21,16 @@ class UpdateUserRequestTest {
 	@Test
 	void testBuildMethod() {
 		final var phoneNumber = "phoneNumber";
-		final var municipalityId = "municipalityId";
+		final var municipalityName = "municipalityName";
 		final var status = "ACTIVE";
 
 		final var updateUserRequest = UpdateUserRequest.create()
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName(municipalityName)
 			.withStatus(status);
 
 		assertThat(updateUserRequest.getPhoneNumber()).isEqualTo(phoneNumber);
-		assertThat(updateUserRequest.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(updateUserRequest.getMunicipalityName()).isEqualTo(municipalityName);
 		assertThat(updateUserRequest.getStatus()).isEqualTo(status);
 	}
 

--- a/src/test/java/se/sundsvall/users/api/model/UserRequestTest.java
+++ b/src/test/java/se/sundsvall/users/api/model/UserRequestTest.java
@@ -22,18 +22,18 @@ class UserRequestTest {
 	void testBuildMethod() {
 		final var email = "email";
 		final var phoneNumber = "phoneNumber";
-		final var municipalityId = "municipalityId";
+		final var municipalityName = "municipalityName";
 		final var status = "ACTIVE";
 
 		final var userRequest = UserRequest.create()
 			.withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName(municipalityName)
 			.withStatus(status);
 
 		assertThat(userRequest.getEmail()).isEqualTo(email);
 		assertThat(userRequest.getPhoneNumber()).isEqualTo(phoneNumber);
-		assertThat(userRequest.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(userRequest.getMunicipalityName()).isEqualTo(municipalityName);
 		assertThat(userRequest.getStatus()).isEqualTo(status);
 	}
 

--- a/src/test/java/se/sundsvall/users/api/model/UserResponseTest.java
+++ b/src/test/java/se/sundsvall/users/api/model/UserResponseTest.java
@@ -22,18 +22,18 @@ class UserResponseTest {
 	void testBuildMethod() {
 		final var email = "email";
 		final var phoneNumber = "phoneNumber";
-		final var municipalityId = "municipalityId";
+		final var municipalityName = "municipalityName";
 		final var status = "ACTIVE";
 
 		final var userResponse = UserResponse.create()
 			.withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName(municipalityName)
 			.withStatus(status);
 
 		assertThat(userResponse.getEmail()).isEqualTo(email);
 		assertThat(userResponse.getPhoneNumber()).isEqualTo(phoneNumber);
-		assertThat(userResponse.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(userResponse.getMunicipalityName()).isEqualTo(municipalityName);
 		assertThat(userResponse.getStatus()).isEqualTo(status);
 	}
 

--- a/src/test/java/se/sundsvall/users/service/UserServiceTest.java
+++ b/src/test/java/se/sundsvall/users/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import se.sundsvall.users.api.model.UserRequest;
 import se.sundsvall.users.api.model.UserResponse;
 import se.sundsvall.users.integration.db.UserRepository;
 import se.sundsvall.users.integration.db.model.UserEntity;
+import se.sundsvall.users.integration.db.model.enums.Role;
 import se.sundsvall.users.integration.db.model.enums.Status;
 import se.sundsvall.users.service.Mapper.UserMapper;
 import se.sundsvall.users.utility.PasswordEncryption;
@@ -89,7 +90,7 @@ class UserServiceTest {
 		var userRequest = UserRequest.create()
 			.withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName("Sundsvall")
 			.withStatus(status);
 
 		var userEntity = UserEntity.create()
@@ -101,7 +102,7 @@ class UserServiceTest {
 		var userResponse = UserResponse.create()
 			.withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName("Sundsvall")
 			.withStatus(status);
 
 		when(userRepositoryMock.findByEmail(email)).thenReturn(Optional.empty());
@@ -131,7 +132,7 @@ class UserServiceTest {
 		final var userRequestMock = UpdateUserRequest.create()
 			.withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName("Sundsvall")
 			.withStatus(status);
 		final var userEntity = UserEntity.create().withId(id).withEmail(email)
 			.withPhoneNumber(phoneNumber)
@@ -139,7 +140,7 @@ class UserServiceTest {
 			.withStatus(Status.valueOf(status));
 		final var userResponseMock = UserResponse.create().withId(id).withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName("Sundsvall")
 			.withStatus(status);
 		// Mock
 		when(userRepositoryMock.findById(id)).thenReturn(Optional.of(userEntity));
@@ -164,7 +165,7 @@ class UserServiceTest {
 		final var status = "ACTIVE";
 		final var userRequestMock = UpdateUserRequest.create()
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName("Sundsvall")
 			.withStatus(status);
 		final var userEntity = UserEntity.create().withId(id)
 			.withPhoneNumber(phoneNumber)
@@ -172,7 +173,7 @@ class UserServiceTest {
 			.withStatus(Status.valueOf(status));
 		final var userResponseMock = UserResponse.create().withId(id)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName("Sundsvall")
 			.withStatus(status);
 		// Mock
 		when(userRepositoryMock.findById(id)).thenReturn(Optional.of(userEntity));
@@ -194,11 +195,13 @@ class UserServiceTest {
 
 		// Arrange
 		final var email = "Test@testmail.se";
+		when(userRepositoryMock.findByEmail(email)).thenReturn(Optional.of(UserEntity.create().withEmail(email).withRole(Role.USER)));
 
 		// Act
 		userService.deleteUserByEmail(email);
 
 		// Verify/Assert
+		verify(userRepositoryMock).findByEmail(email);
 		verify(userRepositoryMock).deleteByEmail(email);
 
 	}
@@ -208,11 +211,13 @@ class UserServiceTest {
 
 		// Arrange
 		final var personalNumber = "198001011234";
+		when(userRepositoryMock.findByEmail(personalNumber)).thenReturn(Optional.of(UserEntity.create().withEmail(personalNumber).withRole(Role.USER)));
 
 		// Act
 		userService.deleteUserByEmail(personalNumber);
 
 		// Verify/Assert
+		verify(userRepositoryMock).findByEmail(personalNumber);
 		verify(userRepositoryMock).deleteByEmail(personalNumber);
 
 	}
@@ -222,11 +227,13 @@ class UserServiceTest {
 
 		// Arrange
 		final var id = 1L;
+		when(userRepositoryMock.findById(id)).thenReturn(Optional.of(UserEntity.create().withId(id).withRole(Role.USER)));
 
 		// Act
 		userService.deleteUserById(id);
 
 		// Verify/Assert
+		verify(userRepositoryMock).findById(id);
 		verify(userRepositoryMock).deleteById(id);
 
 	}
@@ -296,7 +303,7 @@ class UserServiceTest {
 		final var userResponse1 = UserResponse.create().withId(1L).withEmail("user1@test.se");
 		final var userResponse2 = UserResponse.create().withId(2L).withEmail("user2@test.se");
 
-		when(userRepositoryMock.findAll()).thenReturn(List.of(userEntity1, userEntity2));
+		when(userRepositoryMock.findAllByRole(Role.USER)).thenReturn(List.of(userEntity1, userEntity2));
 		when(userMapperMock.toUserResponse(userEntity1)).thenReturn(userResponse1);
 		when(userMapperMock.toUserResponse(userEntity2)).thenReturn(userResponse2);
 
@@ -305,7 +312,7 @@ class UserServiceTest {
 		assertThat(result)
 			.hasSize(2)
 			.containsExactly(userResponse1, userResponse2);
-		verify(userRepositoryMock).findAll();
+		verify(userRepositoryMock).findAllByRole(Role.USER);
 		verify(userMapperMock).toUserResponse(userEntity1);
 		verify(userMapperMock).toUserResponse(userEntity2);
 	}

--- a/src/test/java/se/sundsvall/users/service/UserServiceTest.java
+++ b/src/test/java/se/sundsvall/users/service/UserServiceTest.java
@@ -146,6 +146,7 @@ class UserServiceTest {
 		when(userRepositoryMock.findById(id)).thenReturn(Optional.of(userEntity));
 		when(userRepositoryMock.save(userEntity)).thenReturn(userEntity);
 		when(userMapperMock.toUserResponse(userEntity)).thenReturn(userResponseMock);
+		when(userMapperMock.resolveMunicipalityId("Sundsvall")).thenReturn(municipalityId);
 
 		// Act
 		final var updatedUser = userService.updateUserById(userRequestMock, id);
@@ -177,9 +178,9 @@ class UserServiceTest {
 			.withStatus(status);
 		// Mock
 		when(userRepositoryMock.findById(id)).thenReturn(Optional.of(userEntity));
-
 		when(userRepositoryMock.save(userEntity)).thenReturn(userEntity);
 		when(userMapperMock.toUserResponse(userEntity)).thenReturn(userResponseMock);
+		when(userMapperMock.resolveMunicipalityId("Sundsvall")).thenReturn(municipalityId);
 
 		// Act
 		final var updatedUser = userService.updateUserById(userRequestMock, id);

--- a/src/test/java/se/sundsvall/users/service/mapper/UserMapperTest.java
+++ b/src/test/java/se/sundsvall/users/service/mapper/UserMapperTest.java
@@ -37,7 +37,7 @@ class UserMapperTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getEmail()).isEqualTo(email);
 		assertThat(result.getPhoneNumber()).isEqualTo(phoneNumber);
-		assertThat(result.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(result.getMunicipalityName()).isEqualTo("Sundsvall");
 		assertThat(result.getStatus()).isEqualTo(status);
 	}
 
@@ -46,13 +46,13 @@ class UserMapperTest {
 		// Arrange
 		final var email = "TestMail123@mail.se";
 		final var phoneNumber = "99070121212";
-		final var municipalityId = "2281";
+		final var municipalityName = "Sundsvall";
 		final var status = "ACTIVE";
 		final String password = "password";
 
 		final var userRequest = UserRequest.create().withEmail(email)
 			.withPhoneNumber(phoneNumber)
-			.withMunicipalityId(municipalityId)
+			.withMunicipalityName(municipalityName)
 			.withStatus(status);
 		// Act
 		final var result = userMapper.toUserEntity(userRequest, password);
@@ -60,7 +60,7 @@ class UserMapperTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getEmail()).isEqualTo(email);
 		assertThat(result.getPhoneNumber()).isEqualTo(phoneNumber);
-		assertThat(result.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(result.getMunicipalityId()).isEqualTo("2281");
 		assertThat(result.getStatus()).isEqualTo(Status.valueOf(status));
 		assertThat(result.getPassword()).isEqualTo(password);
 	}


### PR DESCRIPTION
## Summary

  - Renamed `municipalityId` to `municipalityName` across all request/response models — the field now accepts both a municipality name (`Sundsvall`) and a municipality ID (`2281`)
  - Added `@ValidMunicipalityName` custom constraint backed by `MunicipalityUtils.existsByName` and `existsById`
  - `UserMapper` now resolves the stored municipality ID to a human-readable name in responses, and resolves name/ID to an ID when persisting
  - `UserService.getAllUsers` now returns only users with role `USER` via `findAllByRole(Role.USER)`
  - `deleteUserByEmail` and `deleteUserById` now throw `404` if user is not found and `403` if the user is an admin
  -  Fixed failing unit tests caused by service changes: delete methods now require
    findByEmail/findById mocks, and getAllUsers mock updated from findAll() to findAllByRole(Role.USER)
  - Updated integration test fixtures to use `municipalityName` as JSON key

  ## Test plan

  - [ ] `mvn test` — all unit tests pass
  - [ ] `mvn verify -P integration-test` — all integration tests pass
  - [ ] `POST /users` accepts both `Sundsvall` and `2281` as `municipalityName`
  - [ ] `GET /users/{id}` returns `municipalityName` as a human-readable name
  - [ ] `DELETE` returns `404` for unknown user, `403` for admin user
  - [ ] `GET /users` returns only users with role `USER`

fixes: #47 